### PR TITLE
Revert "Content improvements and responsive navigation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
 # Openframe Landing Site
 
 The openframe.io website.
-
-## Deploy
-
-Any changes to the master branch are immediately available at https://openframe.io/.

--- a/css/landing-manual.css
+++ b/css/landing-manual.css
@@ -31,7 +31,6 @@ body {
     letter-spacing: normal;
     font-weight: 300;
     font-family: "Lato", sans-serif;
-    padding-top: 70px; 
 }
 
 .container-wide {
@@ -106,26 +105,29 @@ h6 {
     text-align: center;
 }
 
-nav.navbar {
-  border: none;
-  background-color: white;
-  font-weight: 400;
+.top-nav-wrap {
+    padding-right: 20px;
 }
 
-
-#navbar a {
-  color: #3a3a3a;
-  border: none;
-  padding: 15px 30px;
+ul.top-nav {
+    text-align: right;
 }
 
-#navbar a:hover {
-  color: #999;
+ul.top-nav li {
+    display: inline-block;
+    padding: 15px 15px;
+
 }
 
-.navbar-toggle {
-  background-color: white;
-  border: none;
+ul.top-nav li a {
+    display: block;
+    text-decoration: none;
+    border-bottom: none;
+    font-weight: 400;
+}
+
+ul.top-nav li a:hover {
+    color: #999;
 }
 
 .openframe {
@@ -325,11 +327,6 @@ ul.features li.see-more a {
 .q-a a {
     color: #FFF;
     text-align: center;
-    border-bottom-color: #FFF;
-}
-
-.q-a a:hover {
-  color: #999;
 }
 
 .q-a h5 {
@@ -392,17 +389,9 @@ ul.features li.see-more a {
  */
 
 @media (min-width: 768px) {
-    /* .navbar {
+    .navbar {
         border-bottom: 1px solid #777777;
-    } */
-    #navbar {
-      padding: 0px 15px;      
     }
-    
-    #navbar a {
-      padding: 15px 15px;
-    }
-    
     html#Website body .container {
         width: 700px;
     }
@@ -415,6 +404,16 @@ ul.features li.see-more a {
 }
 
 @media (max-width: 767px) {
+
+    ul.top-nav {
+        text-align: center;
+        padding-left: 0px;
+    }
+
+    .top-nav-wrap {
+        text-align: center;
+        padding-right: 0px
+    }
 
     .row {
         margin-right: 0px;

--- a/index.html
+++ b/index.html
@@ -7,37 +7,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Openframe</title>
     <link href='https://fonts.googleapis.com/css?family=Lato:400,300,300italic,400italic,700,700italic,900' rel='stylesheet' type='text/css'>
-    <link rel='shortcut icon' type='image/x-icon' href='img/favicon.ico' />
-    <link rel="stylesheet" type="text/css" href="vendor/bootstrap/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" type="text/css" href="css/landing-manual.css">
+    <link rel='shortcut icon' type='image/x-icon' href='https://openframeproject.github.io/img/favicon.ico' />
+    <link rel="stylesheet" type="text/css" href="https://openframeproject.github.io/vendor/bootstrap/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="https://openframeproject.github.io/css/landing-manual.css">
     <!--<link rel="stylesheet" type="text/css" href="/css/landing-manual.css">-->
 
 </head>
 
 <body>
 
-    <nav class="navbar navbar-default navbar-fixed-top">
-        <div class="container-fluid">
-          <div class="navbar-header">
-            <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
-              <span class="sr-only">Toggle navigation</span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-              <span class="icon-bar"></span>
-            </button>
-          </div>
-          <div id="navbar" class="navbar-collapse collapse">
-            <ul class="nav navbar-nav navbar-right">
-              <li><a href="https://openframe.io/stream">Artwork stream</a></li>
-              <li><a href="https://docs.openframe.io/">Documentation</a></li>
-              <li><a href="https://openframe.discourse.group/">Forum</a></li>
-              <li><a href="https://github.com/OpenFrameProject">Contribute</a></li>
-            </ul>
-          </div><!--/.nav-collapse -->
-        </div><!--/.container-fluid -->
-      </nav>
-    
-    
+    <!-- Nav, Page Heading, Preview Image -->
+    <div class="top-nav-wrap">
+        <ul class="top-nav">
+            <li><a href="http://docs.openframe.io/frame-setup-guide">Setup a frame</a></li>
+            <li><a href="https://openframe.io/stream">Explore the web app</a></li>
+        </ul>
+    </div>
     <div class="container-wide">
         <div class="row page-header splash-header">
             <div class="col-md-12">
@@ -193,13 +178,6 @@
                     </section>
 
                     <section>
-                    <h5>Where can I find help?</h5>
-
-                    <p>First, have a look at our <a href="https://docs.openframe.io/">documentation</a> and check if you might find a solution to your problem on the <a href="https://openframe.discourse.group/">forum</a>.</p>
-                    <p>In addition, it might be worth checking if your issue has been described in the <a href="https://github.com/OpenframeProject/Openframe/issues">Openframe for Raspberry Pi</a> and <a href="https://github.com/OpenframeProject/Openframe-WebApp/issues">Openframe Web App</a> issue trackers.</p>
-                    </section>
-
-                    <section>
                     <h5>What artwork can I display?</h5>
 
                     <p>The platform uses 'format' plugins which describe how to run artworks. At present, we'll be releasing plugins for images, video, websites, and shaders, but artists are free to create extensions which can run other types of artwork.</p>
@@ -210,7 +188,7 @@
                     <section>
                     <h5>The installation seems complicated, I just want to buy a frame.</h5>
 
-                    <p>Openframe is not a product. However, there are an ever growing number of existing commercial products that you can buy, plug to the wall, and <em>voilà</em> &mdash; they work. Check out <a href="https://www.electricobjects.com/" target="_blank">Electric Objects</a> or <a href="https://frm.fm/" target="_blank">Framed</a>.</p>
+                    <p>Openframe is not a product. However, there are an ever growing number of existing commercial products that you can buy, plug to the wall, and <em>voilà</em> &mdash; they work. Check out <a href="https://www.electricobjects.com/">Electric Objects</a> or <a href="https://frm.fm/">Framed</a>.</p>
                     </section>
 
 
@@ -233,8 +211,6 @@
             </div>
         </div>
     </div>
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-    <script src="vendor/bootstrap/dist/js/bootstrap.min.js"></script>
 </body>
 
 <!-- Google Analytics -->


### PR DESCRIPTION
Reverts OpenframeProject/openframeproject.github.io#3

Relative links for resources don't work, at least not like this.

![image](https://user-images.githubusercontent.com/266111/77930624-bbbf4700-7270-11ea-81fd-5c895157f5f9.png)
